### PR TITLE
feat: ✨ added new benchmarks for comparison to manual mapping

### DIFF
--- a/MapDataReader.Benchmarks/Program.cs
+++ b/MapDataReader.Benchmarks/Program.cs
@@ -63,10 +63,30 @@ namespace MapDataReader.Benchmarks
 		}
 
 		[Benchmark]
-		public void MapDataReader_ViaMapaDataReader()
+		public void MapDataReader_ViaMapDataReader()
 		{
 			var dr = _dt.CreateDataReader();
 			var list = dr.ToTestClass();
+		}
+
+		[Benchmark]
+		public void MapDataReader_ViaManualMap()
+		{
+			var dr = _dt.CreateDataReader();
+
+			var list = new List<TestClass>();
+			while (dr.Read())
+			{
+				list.Add(new TestClass
+				{
+					String1 = dr["String1"] as string,
+					String2 = dr["String2"] as string,
+					String3 = dr["String3"] as string,
+					Int = dr.GetInt32(3),
+					Int2 = dr.GetInt32(4),
+					IntNullable = dr["IntNullable"] as int?
+				});
+			}
 		}
 
 		static DataTable _dt;
@@ -99,8 +119,8 @@ namespace MapDataReader.Benchmarks
 		public string String1 { get; set; }
 		public string String2 { get; set; }
 		public string String3 { get; set; }
-		public string Int { get; set; }
-		public string Int2 { get; set; }
+		public int Int { get; set; }
+		public int Int2 { get; set; }
 		public int? IntNullable { get; set; }
 	}
 }

--- a/MapDataReader.Benchmarks/Program.cs
+++ b/MapDataReader.Benchmarks/Program.cs
@@ -70,7 +70,27 @@ namespace MapDataReader.Benchmarks
 		}
 
 		[Benchmark]
-		public void MapDataReader_ViaManualMap()
+		public void MapDataReader_ViaManualMap_CastMethods()
+		{
+			var dr = _dt.CreateDataReader();
+
+			var list = new List<TestClass>();
+			while (dr.Read())
+			{
+				list.Add(new TestClass
+				{
+					String1 = (string)dr["String1"],
+					String2 = (string)dr["String2"],
+					String3 = (string)dr["String3"],
+					Int = (int)dr["Int"],
+					Int2 = (int)dr["Int2"],
+					IntNullable = (int?)dr["IntNullable"]
+				});
+			}
+		}
+
+		[Benchmark]
+		public void MapDataReader_ViaManualMap_AsMethods()
 		{
 			var dr = _dt.CreateDataReader();
 
@@ -82,9 +102,29 @@ namespace MapDataReader.Benchmarks
 					String1 = dr["String1"] as string,
 					String2 = dr["String2"] as string,
 					String3 = dr["String3"] as string,
+					Int = dr["Int"] as int? ?? 0,
+					Int2 = dr["Int2"] as int? ?? 0,
+					IntNullable = dr["IntNullable"] as int?
+				});
+			}
+		}
+
+		[Benchmark]
+		public void MapDataReader_ViaManualMap_GetMethods()
+		{
+			var dr = _dt.CreateDataReader();
+
+			var list = new List<TestClass>();
+			while (dr.Read())
+			{
+				list.Add(new TestClass
+				{
+					String1 = dr.GetString(0),
+					String2 = dr.GetString(1),
+					String3 = dr.GetString(2),
 					Int = dr.GetInt32(3),
 					Int2 = dr.GetInt32(4),
-					IntNullable = dr["IntNullable"] as int?
+					IntNullable = dr.GetInt32(5) // this wouldn't work if the value is null though, this is just for benchmarking
 				});
 			}
 		}


### PR DESCRIPTION
This just adds a benchmark for comparing to a manually mapped data reader, using `cast`, the `as` methods, and the `get` methods. It shows that this project is faster than the `cast` and `as` methods, and comparable to doing it via the `get`.

I'd suggest adding the reflection benchmarks for the data reader as well, so people can do a comparison of those.

|                                 Method |          Mean |          Error |       StdDev |   Gen0 |   Gen1 | Allocated |
|--------------------------------------- |--------------:|---------------:|-------------:|-------:|-------:|----------:|
|                MapDatareader_ViaDapper | 130,038.43 ns |  23,380.156 ns | 1,281.545 ns | 7.5684 | 1.2207 |  145472 B |
|         MapDataReader_ViaMapDataReader | 145,014.83 ns |  18,917.702 ns | 1,036.943 ns | 7.5684 | 1.2207 |  145712 B |
| MapDataReader_ViaManualMap_CastMethods | 160,137.67 ns |   3,812.999 ns |   209.003 ns | 7.5684 | 1.2207 |  145408 B |
|   MapDataReader_ViaManualMap_AsMethods | 212,504.85 ns | 120,474.966 ns | 6,603.639 ns | 7.5684 | 1.2207 |  145408 B |
|  MapDataReader_ViaManualMap_GetMethods | 126,697.73 ns |  25,508.688 ns | 1,398.217 ns | 7.5684 | 1.2207 |  145408 B |
